### PR TITLE
Disable build on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,3 +120,7 @@ script:
 # notifications
 notifications:
   slack: revbayes:bQO6VTun0Orhx2NiKktVPDsS
+
+branches:
+  except:
+  - /.*/


### PR DESCRIPTION
Disable automatic builds for all branches when a commit is pushed. This will make it so the travis checks are only executed for pull requests (hopefully).