### PR TITLE
Fix covarion scale

### DIFF
--- a/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.cpp
@@ -621,3 +621,12 @@ void AbstractRateMatrix::setDiagonal(void)
     // set flags
     needs_update = true;
 }
+
+std::vector<int> AbstractRateMatrix::get_emitted_letters() const
+{
+    std::vector<int> emit(num_states);
+    for(int i=0;i<num_states;i++)
+        emit[i] = i;
+
+    return emit;
+}

--- a/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.h
@@ -46,7 +46,8 @@ namespace RevBayesCore {
         double                              getRate(size_t from, size_t to, double age, double rate) const;         //!< Calculate the rate from state i to state j over the given time interval scaled by a rate
         void                                rescaleToAverageRate(double r);                                                             //!< Rescale the rate matrix such that the average rate is "r"
         void                                setDiagonal(void);                                                                          //!< Set the diagonal such that each row sums to zero
-        
+        virtual std::vector<int>            get_emitted_letters() const;                                                                //!<Find out what alphet letter each state emits        
+
         // pure virtual methods you have to overwrite
         virtual double                      averageRate(void) const = 0;                                                                //!< Calculate the average rate
         virtual void                        calculateTransitionProbabilities(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const = 0;   //!< Calculate the transition matrix

--- a/src/core/datatypes/phylogenetics/ratematrix/GeneralRateMatrix.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/GeneralRateMatrix.cpp
@@ -40,11 +40,17 @@ GeneralRateMatrix& GeneralRateMatrix::assign(const Assignable &m)
 double GeneralRateMatrix::averageRate(void) const
 {
     std::vector<double> stationary_freqs = getStationaryFrequencies();
+
+    std::vector<int> emit = get_emitted_letters();
     
     double ave = 0.0;
     for (size_t i=0; i<num_states; i++)
     {
-        ave += -stationary_freqs[i] * (*the_rate_matrix)[i][i];
+        for (size_t j=0; j<num_states; j++)
+        {
+            if (emit[i] != emit[j])
+                ave += stationary_freqs[i] * (*the_rate_matrix)[i][j];
+        }
     }
     
     return ave;

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_Covarion.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_Covarion.cpp
@@ -130,6 +130,13 @@ RateMatrix_Covarion& RateMatrix_Covarion::assign(const Assignable &m)
     
 }
 
+std::vector<int> RateMatrix_Covarion::get_emitted_letters() const
+{
+    std::vector<int> emit(num_states);
+    for(int i=0;i<num_states;i++)
+        emit[i] = i % num_states_per_class;
+    return emit;
+}
 
 /** Do precalculations on eigenvectors */
 void RateMatrix_Covarion::calculateCijk(void)

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_Covarion.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_Covarion.h
@@ -49,6 +49,7 @@ namespace RevBayesCore {
         // overloaded operators
         RateMatrix_Covarion&                operator=(const RateMatrix_Covarion& r);
         virtual RateMatrix_Covarion&        assign(const Assignable &m);
+        std::vector<int>                    get_emitted_letters(void) const;
         
         // RateMatrix functions
         void                                calculateTransitionProbabilities(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const;   //!< Calculate the transition matrix

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.cpp
@@ -34,7 +34,12 @@ RateMatrix_FreeK::RateMatrix_FreeK(size_t n) : GeneralRateMatrix( n ),
     cc_ijk.resize(num_states * num_states * num_states);
     
     matrixProducts = new std::vector<MatrixReal>();
-    
+
+    // Initialize emit_letters to [0...N-1]
+    emit_letters.resize(num_states);
+    for(int i=0;i<num_states;i++)
+        emit_letters[i] = i;
+
     update();
 }
 
@@ -50,6 +55,11 @@ RateMatrix_FreeK::RateMatrix_FreeK(size_t n, bool r) : GeneralRateMatrix( n ),
     
     matrixProducts = new std::vector<MatrixReal>();
     
+    // Initialize emit_letters to [0...N-1]
+    emit_letters.resize(num_states);
+    for(int i=0;i<num_states;i++)
+        emit_letters[i] = i;
+
     update();
 }
 
@@ -88,6 +98,11 @@ RateMatrix_FreeK::RateMatrix_FreeK(size_t n, bool r, std::string method) : Gener
     
     matrixProducts = new std::vector<MatrixReal>();
     
+    // Initialize emit_letters to [0...N-1]
+    emit_letters.resize(num_states);
+    for(int i=0;i<num_states;i++)
+        emit_letters[i] = i;
+
     update();
 }
 
@@ -792,3 +807,14 @@ void RateMatrix_FreeK::update( void )
     
 }
 
+void RateMatrix_FreeK::set_emitted_letters(const std::vector<int>& emit)
+{
+    assert(emit.size() == num_states);
+
+    emit_letters = emit;
+}
+
+std::vector<int> RateMatrix_FreeK::get_emitted_letters() const
+{
+    return emit_letters;
+}

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.cpp
@@ -23,74 +23,49 @@
 
 using namespace RevBayesCore;
 
-/** Construct rate matrix with n states */
-RateMatrix_FreeK::RateMatrix_FreeK(size_t n) : GeneralRateMatrix( n ),
-    rescale(true),
-    my_method( EIGEN )
+RateMatrix_FreeK::METHOD method_from_string(const std::string& method)
 {
-    
-    theEigenSystem       = new EigenSystem(the_rate_matrix);
-    c_ijk.resize(num_states * num_states * num_states);
-    cc_ijk.resize(num_states * num_states * num_states);
-    
-    matrixProducts = new std::vector<MatrixReal>();
-
-    // Initialize emit_letters to [0...N-1]
-    emit_letters.resize(num_states);
-    for(int i=0;i<num_states;i++)
-        emit_letters[i] = i;
-
-    update();
-}
-
-
-RateMatrix_FreeK::RateMatrix_FreeK(size_t n, bool r) : GeneralRateMatrix( n ),
-    rescale(r),
-    my_method( EIGEN )
-{
-    
-    theEigenSystem       = new EigenSystem(the_rate_matrix);
-    c_ijk.resize(num_states * num_states * num_states);
-    cc_ijk.resize(num_states * num_states * num_states);
-    
-    matrixProducts = new std::vector<MatrixReal>();
-    
-    // Initialize emit_letters to [0...N-1]
-    emit_letters.resize(num_states);
-    for(int i=0;i<num_states;i++)
-        emit_letters[i] = i;
-
-    update();
-}
-
-
-RateMatrix_FreeK::RateMatrix_FreeK(size_t n, bool r, std::string method) : GeneralRateMatrix( n ),
-    rescale(r),
-    my_method( EIGEN )
-{
-    
     // determine the type of matrix exponentiation
     if (method == "scalingAndSquaring")
     {
-        my_method = SCALING_AND_SQUARING;
+        return RateMatrix_FreeK::SCALING_AND_SQUARING;
     }
     else if (method == "scalingAndSquaringPade")
     {
-        my_method = SCALING_AND_SQUARING_PADE;
+        return RateMatrix_FreeK::SCALING_AND_SQUARING_PADE;
     }
     else if (method == "scalingAndSquaringTaylor")
     {
-        my_method = SCALING_AND_SQUARING_TAYLOR;
+        return RateMatrix_FreeK::SCALING_AND_SQUARING_TAYLOR;
     }
     else if (method == "uniformization")
     {
-        my_method = UNIFORMIZATION;
+        return RateMatrix_FreeK::UNIFORMIZATION;
     }
     else if (method == "eigen")
     {
-        my_method = EIGEN;
+        return RateMatrix_FreeK::EIGEN;
     }
-    
+    else
+        return RateMatrix_FreeK::EIGEN; /// We haven't been complaining here, but maybe we should.
+}
+
+/** Construct rate matrix with n states */
+RateMatrix_FreeK::RateMatrix_FreeK(size_t n) : RateMatrix_FreeK(n, true, EIGEN)
+{ }
+
+
+RateMatrix_FreeK::RateMatrix_FreeK(size_t n, bool r) : RateMatrix_FreeK(n, r, EIGEN)
+{ }
+
+
+RateMatrix_FreeK::RateMatrix_FreeK(size_t n, bool r, std::string method) : RateMatrix_FreeK( n, r, method_from_string(method))
+{ }
+
+RateMatrix_FreeK::RateMatrix_FreeK(size_t n, bool r, METHOD method) : GeneralRateMatrix( n ),
+    rescale(r),
+    my_method( method )
+{
     // create the eigen system so the destructor has something to delete
     theEigenSystem       = new EigenSystem(the_rate_matrix);
     c_ijk.resize(num_states * num_states * num_states);

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.h
@@ -52,7 +52,11 @@ namespace RevBayesCore {
         RateMatrix_FreeK*                   clone(void) const;
         void                                fillRateMatrix(void);
         void                                update(void);
+        std::vector<int>                    get_emitted_letters() const;
         
+        // Mutator functions for local state
+        void                                set_emitted_letters(const std::vector<int>& emit);
+
     private:
         void                                calculateCijk(void);                                                                //!< Do precalculations on eigenvectors and their inverse
         void                                tiProbsEigens(double t, TransitionProbabilityMatrix& P) const;                      //!< Calculate transition probabilities for real case
@@ -83,6 +87,9 @@ namespace RevBayesCore {
 
         METHOD                              my_method;
         
+        // members for computing an average rate
+        std::vector<int>                    emit_letters;
+
     };
     
 }

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_FreeK.h
@@ -40,6 +40,8 @@ namespace RevBayesCore {
         RateMatrix_FreeK(size_t k);                                                                                               //!< Construct rate matrix with n states
         RateMatrix_FreeK(size_t k, bool r);
         RateMatrix_FreeK(size_t k, bool r, std::string method);
+        RateMatrix_FreeK(size_t k, bool r, METHOD);
+
         RateMatrix_FreeK(const RateMatrix_FreeK& m);                                                                                //!< Copy constructor
         virtual                         ~RateMatrix_FreeK(void);                                                              //!< Destructor
         

--- a/src/core/functions/phylogenetics/ratematrix/CovarionFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CovarionFunction.cpp
@@ -137,6 +137,13 @@ void CovarionFunction::update( void )
     
     // finally set the rates in the actual matrix
     static_cast< RateMatrix_FreeK* >(value)->setTransitionRates( all_rates_flat );
+
+    // set the emitted letters for each covartion state in the actual matrix
+    std::vector<int> emit(num_states);
+    for(int i=0; i<num_states; i++)
+        emit[i] = i % num_org_states;
+    static_cast< RateMatrix_FreeK* >(value)->set_emitted_letters( emit);
+
     value->update();
 }
 


### PR DESCRIPTION
Both covarion methods get the wrong likelihood because they do not scale branches to the expected number of substitutions.  Instead, they scale branches to the expected number of state changes.

This PR fixes both covarion methods to get the correct likelihood on a test case by computing the averageRate() correctly.  It is now possible to match HKY likelihoods when all clock_rates == 1 without setting rescale=FALSE.

This patch does not address issues where the matrix exponential diverges for weird parameter values.  That will be next.